### PR TITLE
bug fix, made docs better

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,11 @@ There are additionally commands available (taken from the base Slime documentati
 
 ## Configuration
 
+
+Global Variables (`vim.g.xxx`)  have to be created and set by the user.  By default they do not exist.
+
+
 ### Global Variables
-
-Have to be created and set by the user.  By default they do not exist.
-
 
 ---
 
@@ -155,14 +156,20 @@ vim.g.ruled_status = true
 Boolean that, when true, shows the coordinates of the cursor in the overridden status bar set by `vim.g.override_status`. Only takes effect if `vim.g.override_status` is `true`.
 
 
+### Mappings
+
+See the Usage and Example Installation sections for available commands, functions and mapping examples.
+
 
 ## Glossary
 
-PID
-:   Process IDentifier in Linux and MacOS. A unique number assigned to
-    each process when it\'s created. Corresponds to `terminal_job_pid`
-    in Neovim\'s `getbufinfo()` command.
+### PID
+   Process identifier in Linux and MacOS. A unique number assigned to
+    each process when it is created. Corresponds to `terminal_job_pid`
+    in Neovim's `getbufinfo()` command. Neovim also has a number analogous to PID in Windows.
 
-Job ID
-:   Neovim\'s internal identifier for a running terminal process.
+    TODO: Investigate what PID means in Neovim on Windows.
+
+### Job ID
+   Neovim's internal identifier for a running terminal process.
     Referenced as `terminal_job_id` in `getbufinfo()`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Note that `vim-slime-ext-plugins` is necessary as a dependency.
 
 Be aware that the values here are the ones preferred by the plugin author, not the defaults. The default is for the `vim.g` variables to not exist, which has the same effect as `false`.
 
+It is recommended to use `init` to set global variables so that they are present before the plugin loads. Otherwise they might not take effect.
+
 ```lua
 {
 'Klafyvel/vim-slime-ext-neovim',

--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # vim-slime-ext-neovim
 
-A plugin to send code from a neovim Neovim buffer to a running Neovim terminal, enhancing your development workflow. This plugin uses Neovim's built-in terminal and extends [vim-slime-ext-plugins](https://github.com/jpalardy/vim-slime-ext-plugins/).
+A plugin to send code from a Neovim buffer to a running Neovim terminal. This plugin uses Neovim's built-in terminal and extends [vim-slime-ext-plugins](https://github.com/jpalardy/vim-slime-ext-plugins/).
 
+## What This Is
+
+Say you are writing code in, for example, python. One way of quickly testing code is to have a terminal where you repeatedly source commands from the terminal.  For example if your file is `hello.py` you might have an editor open in one window, and a shell open in another where you input `python hello.py` after you save changes.  Another way might be to copy and paste your code to an open python session in the terminal.
+
+The [vim-slime](https://github.com/jpalardy/vim-slime) plugin allows the user to set keybindings to send text directly from a Vim or Neovim buffer to a running shell or window. Configuration code for each target is included in that repository.
+
+[vim-slime-ext-plugins](https://github.com/jpalardy/vim-slime-ext-plugins/) in contrast provides infrastructure for sending text to a target, and leaves the community to develop plugins for each target.  
+
+This plugin extends `vim-slime-ext-plugins` and targets the Neovim terminal.
 
 ## Example of Installation and Configuration Using lazy.nvim
 
@@ -32,9 +41,7 @@ end
 
 Used to send text using the external PID rather than Neovim's internal job id. Setting this to a nonzero value (evaluated as `true` in vimscript), as is done here, is recommended because the PID is the number displayed on the status line of a terminal buffer, making it easier to select the desired terminal. This recommended setting is not the default because neovim  uses it's internal job id to send text to a terminal; the plugin has a function that translates the PID to the inernal job id.
 
-##### Additional Note
 
-Recall that when configuring neovim in lua, variables in the global `g:` namespace are set with `vim.g.foo = bar`.
 
 ## Vimscript, Configuration Only
 
@@ -56,15 +63,7 @@ xmap gz <Plug>SlimeRegionSend
 
 
 
-## What This Is
 
-Say you are writing code in, for example, python. One way of quickly testing code is to have a terminal where you repeatedly source commands from the terminal.  For example if your file is `hello.py` you might have an editor open in one window, and a shell open in another where you input `python hello.py` after you save changes.  Another way might be to copy and paste your code to an open python session in the terminal.
-
-The [vim-slime](https://github.com/jpalardy/vim-slime) plugin allows the user to set keybindings to send text directly from a Vim or Neovim buffer to a running shell or window. Configuration code for each target is included in that repository.
-
-[vim-slime-ext-plugins](https://github.com/jpalardy/vim-slime-ext-plugins/) in contrast provides infrastructure for sending text to a target, and leaves the community to develop plugins for each target.  
-
-This plugin extends `vim-slime-ext-plugins` and targets the Neovim terminal.
 
 ## How to Use
 

--- a/README.md
+++ b/README.md
@@ -1,103 +1,102 @@
 # vim-slime-ext-neovim
 
-A plugin to send code from a Neovim buffer to a running Neovim terminal. This plugin uses Neovim's built-in terminal and extends [vim-slime-ext-plugins](https://github.com/jpalardy/vim-slime-ext-plugins/).
+A plugin to send code from a Neovim buffer to a running Neovim terminal.
+by extending the base functionality of [vim-slime-ext-plugins](https://github.com/jpalardy/vim-slime-ext-plugins/).
 
-## What This Is
+## Introduction
 
-Say you are writing code in, for example, python. One way of quickly testing code is to have a terminal where you repeatedly source commands from the terminal.  For example if your file is `hello.py` you might have an editor open in one window, and a shell open in another where you input `python hello.py` after you save changes.  Another way might be to copy and paste your code to an open python session in the terminal.
+Imagine that you are making quick changes to, for example, a python script.  One approach to test the changes is to copy and paste into an open python REPL (perhaps using the `+` or `*` registers which can be synced to the system clipboard).  With this plugin you can send the code directly to the REPL using Vim operator /motion+text object combinations. For example, if `SlimeMotionSend` is mapped to `gz`, `gzip` can be used to send an uninterrupted block of text (a paragraph) to the REPL. This of course works for any program running in the terminal that accepts text input.
 
-The [vim-slime](https://github.com/jpalardy/vim-slime) plugin allows the user to set keybindings to send text directly from a Vim or Neovim buffer to a running shell or window. Configuration code for each target is included in that repository.
 
-[vim-slime-ext-plugins](https://github.com/jpalardy/vim-slime-ext-plugins/) in contrast provides infrastructure for sending text to a target, and leaves the community to develop plugins for each target.  
-
-This plugin extends `vim-slime-ext-plugins` and targets the Neovim terminal.
-
-## Example of Installation and Configuration Using lazy.nvim
-
-```lua
-{
-'Klafyvel/vim-slime-ext-neovim',
-dependencies = { "jpalardy/vim-slime-ext-plugins" },
-config = function()
-	vim.g.slime_target_send = "slime_neovim#send"
-	vim.g.slime_target_config = "slime_neovim#config"
-
-	-- allows use of PID rather than internal job_id for config see note below this codeblock
-	vim.g.slime_input_pid = 1
-
-	-- optional but useful keymaps:
-	---- send text using gz as operator before motion or text object
-	vim.keymap.set("n", "gz", "<Plug>SlimeMotionSend", { remap = true })
-	---- send line of text
-	vim.keymap.set("n", "gzz", "<Plug>SlimeLineSend", { remap = true })
-	---- send visual selection
-	vim.keymap.set("x", "gz", "<Plug>SlimeRegionSend", { remap = true })
-end
-}
+## Example Installation Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```
+{
+    'Klafyvel/vim-slime-ext-neovim',
+    dependencies = { "jpalardy/vim-slime-ext-plugins" },
+}
+```
+
+## Usage
+
+Use the plug mappingss from `vim-slime-ext-plugins` to send text to a running Neovim terminal. Upon running them, if a terminal has not been configured as the target, the user will be prompted to select one based on either the Job Id number or the PID. 
+
+`<Plug>SlimeRegionSend` sends a visually selected region to the terminal.
+`<Plug>SlimeLineSend` sends a line to the terminal.
+`<Plug>SlimeMotionSend` send text to terminal based on motion or text-object.
+`<Plug>SlimeParagraphSend` sends a paragraph to the terminal.
+`<Plug>SlimeConfig` configure the target terminal for the current buffer.
+
+## Configuration
+
+### Variables defined byt `vim-slime-ext-plugins`
+
+```
+vim.g.slime_target_config = "slime_neovim#config"
+```
+This variable holds the function that configures which terminal text is sent to. Here we set it to the configuration function defined in this plugin. 
+
+
+```
+vim.g.slime_target_send = "slime_neovim#send"
+```
+
+This variable holds the function that actually sends text to the terminal. We set it to the function defined in this plugin.
+
+
+
+
+vim.g.slime_input_pid = 1
+vim.keymap.set("n", "gz", "<Plug>SlimeMotionSend", { remap = true })
+vim.keymap.set("n", "gzz", "<Plug>SlimeLineSend", { remap = true })
+vim.keymap.set("x", "gz", "<Plug>SlimeRegionSend", { remap = true })
+```
+
 
 ### Note on `g:slime_input_pid`
 
-Used to send text using the external PID rather than Neovim's internal job id. Setting this to a nonzero value (evaluated as `true` in vimscript), as is done here, is recommended because the PID is the number displayed on the status line of a terminal buffer, making it easier to select the desired terminal. This recommended setting is not the default because neovim  uses it's internal job id to send text to a terminal; the plugin has a function that translates the PID to the inernal job id.
+Using the external PID instead of Neovim\'s internal job id is
+recommended for ease of use. This setting isn\'t default because Neovim
+internally uses its job id. However, setting this to a nonzero value
+allows users to utilize the PID displayed on the terminal\'s status
+line.
 
+## Usage
 
+Check out `:h slime.txt` for default keybindings. Here\'s a brief
+summary:
 
-## Vimscript, Configuration Only
+-   `gz[operator/motion]`: Send text using an operator or motion.
+-   In visual mode, `gz` sends the selected text.
+-   `gzz` sends the current line.
 
-```vim
-let g:slime_target_send = "slime_neovim#send"
-let g:slime_target_config = "slime_neovim#config"
+When sending text, the plugin prioritizes the most recently opened
+terminal. If no terminals are open, you\'ll be prompted to open one. Use
+`<C-w>s` or `<C-w>v` and then `:terminal` to do so. To reconfigure a
+buffer\'s terminal connection, call `:SlimeConfig`.
 
-" Use external PID instead of Neovim's internal job id
-let g:slime_input_pid = 1
+## Capabilities
 
-" Key mappings:
-" Send text using gz as operator before motion or text object
-nmap gz <Plug>SlimeMotionSend
-" Send line of text
-nmap gzz <Plug>SlimeLineSend
-" Send visual selection
-xmap gz <Plug>SlimeRegionSend
-```
+### Multiple Terminal Tracking
 
+The plugin tracks multiple terminals using `g:slime_last_channel`. If a
+linked terminal closes, the plugin will prompt you to choose another. If
+issues arise, helpful messages guide the process. Feedback is welcome!
 
+### PID or Internal Job ID Configuration
 
-
-
-## How to Use
-
-See `:h slime.txt` for default keybindings to send text to a target. I repeat the suggested additional keymappings from the config section above:
-
-- `gz[operator/motion]`: send text using an operator or motion.
-- In visual mode `gz` can send visually selected text to the target.
-- `gzz` sends the current line to the target.
-
-Of course these are optional and you can do what you want.
-
-When you use one of these motions, the plugin will try to find the most recently opened terminal and select it as the target. You are prompted with the identification number (`terminal_job_id`) or (`terminal_job_pid` if `g:sline_input_pid` is set to a nonzero value).  `terminal_job_pid` is easier to use because that number is displayed on the status line of each terminal buffer. `terminal_job_id` is used by default because that is that Neovim internally uses to send text to the terminals.
-
-If no terminals are open you will be prompted to do so. To do so, open a new split with `<C-w>s` or `<C-w>v` and then enter the command `:terminal`.
-
-Call the `:SlimeConfig` function from an open buffer to reconfigure the terminal connection of that buffer.
-
-## Capabilities Summary
-
-At the risk of repetition, this plugin:
-
-### Keeps Track of Multiple Terminals
-
-It does this using the `g:slime_last_channel` variable which is an array of vimscript dictionaries containing the PIDs (external identifier) and job ids (Neovim internal identifier) of open Neovim terminals. If a connected terminal is closed, upon trying to send text again the user is prompted to pick another terminal, with the next-most recently opened terminal selected by default. If no terminals are available, or if there is misconfiguration,  a helpful message telling you to open a new terminal is displayed. If you find the messages aren't helpful enogh please leave feedback witha  repo maintainer.
-
-
-### Can Use PID or internal job id for configuration
-
-Under the hood Neovim sends text to a running a terminal using the `terminal_job_id`, which are typically low numbers.  Neovim also keeps track of the `terminal_job_pid` which is the system's identifier, and importantly *is displayed on the status line of the terinal buffer*. The default settings are that the user if prompted with a `terminal_job_id` value, because this is what is used by neovim internally to send text to a terminal.  However, because it is readily displayed for each running terminal, `terminal_job_pid` is much easier to manually configure, and that is why `vim.g.slime_input_pid=1` is included in the example configuration (the vimscript equivalent of this is `let g:slime_input_pid=1`.
-
+Neovim sends text to a terminal using the `terminal_job_id`, but it also
+tracks the system\'s `terminal_job_pid`. The latter is displayed on each
+terminal\'s status line, making it more user-friendly for manual
+configuration.
 
 ## Glossary
 
-- `PID`: In Linux, PID stands for "Process IDentifier". A PID is a unique number that is automatically assigned to each process when it is created on a Unix-like operating system. A process is an executing (i.e., running) instance of a program. Applies to Macos as well. Represented as `terminal_job_pid` in under the `variables` field of the `getbufinfo()` Neovim vimscript command.
+PID
+:   Process IDentifier in Linux and MacOS. A unique number assigned to
+    each process when it\'s created. Corresponds to `terminal_job_pid`
+    in Neovim\'s `getbufinfo()` command.
 
-
-- `job id`: the internal identifier that Neovim attaches to a running terminal process. `termnal_job_id` is the corresponding field in the `variables` section of `getbufinfo()`.
+Job ID
+:   Neovim\'s internal identifier for a running terminal process.
+    Referenced as `terminal_job_id` in `getbufinfo()`.

--- a/README.md
+++ b/README.md
@@ -18,24 +18,24 @@ Be aware that the values here are the ones preferred by the plugin author, not t
 
 ```lua
 {
-	'Klafyvel/vim-slime-ext-neovim',
-	dependencies = { "jpalardy/vim-slime-ext-plugins" },
-	init = function()
-		vim.g.slime_no_mappings = true -- I prefer to turn off default mappings; see below for more details
-		-- these next two are essential, telling vim-slime-ext-plugins to use the functions from this plugin
-		vim.g.slime_target_send = "slime_neovim#send"
-		vim.g.slime_target_config = "slime_neovim#config"
-		vim.g.slime_input_pid = false -- use Neovim's internal Job ID rather than PID to select a terminal
-		vim.g.override_status = true -- Show the Job ID and PID in the status bar of a terminal
-		vim.g.ruled_status = true  -- If override_status is true, also show the cursor position in the status bar
-	end,
-	config = function()
+'Klafyvel/vim-slime-ext-neovim',
+dependencies = { "jpalardy/vim-slime-ext-plugins" },
+init = function()
+	vim.g.slime_no_mappings = true -- I prefer to turn off default mappings; see below for more details
+	-- these next two are essential, telling vim-slime-ext-plugins to use the functions from this plugin
+	vim.g.slime_target_send = "slime_neovim#send"
+	vim.g.slime_target_config = "slime_neovim#config"
+	vim.g.slime_input_pid = false -- use Neovim's internal Job ID rather than PID to select a terminal
+	vim.g.override_status = true -- Show the Job ID and PID in the status bar of a terminal
+	vim.g.ruled_status = true  -- If override_status is true, also show the cursor position in the status bar
+end,
+config = function()
 
-		vim.keymap.set("n", "gz", "<Plug>SlimeMotionSend", { remap = true, silent = false })
-		vim.keymap.set("n", "gzz", "<Plug>SlimeLineSend", { remap = true, silent = false })
-		vim.keymap.set("x", "gz", "<Plug>SlimeRegionSend", { remap = true, silent = false })
+	vim.keymap.set("n", "gz", "<Plug>SlimeMotionSend", { remap = true, silent = false })
+	vim.keymap.set("n", "gzz", "<Plug>SlimeLineSend", { remap = true, silent = false })
+	vim.keymap.set("x", "gz", "<Plug>SlimeRegionSend", { remap = true, silent = false })
 
-	end,
+end,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # vim-slime-ext-neovim
 
-A plugin to send code from a Neovim buffer to a running Neovim terminal.
-by extending the base functionality of [vim-slime-ext-plugins](https://github.com/jpalardy/vim-slime-ext-plugins/).
+A plugin to send code from a Neovim buffer to a running Neovim terminal by extending the base functionality of [vim-slime-ext-plugins](https://github.com/jpalardy/vim-slime-ext-plugins/).
 
 ## Introduction
 
 Imagine that you are making quick changes to, for example, a python script.  One approach to test the changes is to copy and paste into an open python REPL (perhaps using the `+` or `*` registers which can be synced to the system clipboard).  With this plugin you can send the code directly to the REPL using Vim operator /motion+text object combinations. For example, if `SlimeMotionSend` is mapped to `gz`, `gzip` can be used to send an uninterrupted block of text (a paragraph) to the REPL. This of course works for any program running in the terminal that accepts text input.
 
-
 ## Example Installation Using [lazy.nvim](https://github.com/folke/lazy.nvim)
+
+Note that `vim-slime-ext-plugins` is necessary.
 
 ```
 {
@@ -19,34 +19,55 @@ Imagine that you are making quick changes to, for example, a python script.  One
 
 ## Usage
 
-Use the plug mappingss from `vim-slime-ext-plugins` to send text to a running Neovim terminal. Upon running them, if a terminal has not been configured as the target, the user will be prompted to select one based on either the Job Id number or the PID. 
+Use the `<Plug>` mappings from `vim-slime-ext-plugins` to send text to a running Neovim terminal. Upon running them, if a terminal has not been configured as the target, the user will be prompted to select one based on either the Job Id number or the PID, or to open one if no terminal is detected.
 
 `<Plug>SlimeRegionSend` sends a visually selected region to the terminal.
 `<Plug>SlimeLineSend` sends a line to the terminal.
-`<Plug>SlimeMotionSend` send text to terminal based on motion or text-object.
+`<Plug>SlimeMotionSend` sends text to terminal based on motion or text-object.
 `<Plug>SlimeParagraphSend` sends a paragraph to the terminal.
 `<Plug>SlimeConfig` configure the target terminal for the current buffer.
 
 ## Configuration
 
-### Variables defined byt `vim-slime-ext-plugins`
+### Variables defined by `vim-slime-ext-plugins`
 
 ```
 vim.g.slime_target_config = "slime_neovim#config"
 ```
-This variable holds the function that configures which terminal text is sent to. Here we set it to the configuration function defined in this plugin. 
+
+(defined in `vim-slime-ext-plugins`) This variable holds the function that configures which terminal text is sent to. Here we set it to the configuration function defined in this plugin. 
 
 
 ```
 vim.g.slime_target_send = "slime_neovim#send"
 ```
 
-This variable holds the function that actually sends text to the terminal. We set it to the function defined in this plugin.
+(defined in `vim-slime-ext-plugins`) This variable holds the function that actually sends text to the terminal. We set it to the function defined in this plugin.
+
+
+```
+vim.g.slime_no_mappings = true
+```
+
+Do not define the default mappings from `vim-slime-ext-plugins`.  See documentation of `vim-slime-ext-plugins` for more details.
+
+
+```
+vim.g.slime_input_pid = 0
+```
+
+Boolean that can decides whether you specify the terminal based on the Neovim internal terminal Job ID, or based on the PID that also exists on a system level. Job ID is shorter an for that readsn might be preferred.
+
+
+```
+vim.g.override_status=1
+```
+
+Boolean that overraides the default status bar so that Job ID and terminal PID is displayed in the status bar. Recommended to be true (`1`)
 
 
 
 
-vim.g.slime_input_pid = 1
 vim.keymap.set("n", "gz", "<Plug>SlimeMotionSend", { remap = true })
 vim.keymap.set("n", "gzz", "<Plug>SlimeLineSend", { remap = true })
 vim.keymap.set("x", "gz", "<Plug>SlimeRegionSend", { remap = true })
@@ -82,8 +103,6 @@ buffer\'s terminal connection, call `:SlimeConfig`.
 The plugin tracks multiple terminals using `g:slime_last_channel`. If a
 linked terminal closes, the plugin will prompt you to choose another. If
 issues arise, helpful messages guide the process. Feedback is welcome!
-
-### PID or Internal Job ID Configuration
 
 Neovim sends text to a terminal using the `terminal_job_id`, but it also
 tracks the system\'s `terminal_job_pid`. The latter is displayed on each

--- a/README.md
+++ b/README.md
@@ -1,41 +1,110 @@
 # vim-slime-ext-neovim
 
-A plugin to send code from a Neovim buffer to a running Neovim terminal by extending the base functionality of [vim-slime-ext-plugins](https://github.com/jpalardy/vim-slime-ext-plugins/).
+A plugin to send code from a Neovim buffer to a running Neovim terminal by extending [vim-slime-ext-plugins](https://github.com/jpalardy/vim-slime-ext-plugins/).
+
+That plugin is itself a modification of [vim-slime](https://github.com/jpalardy/vim-slime) to move platform-specific functionality to extension plugins like this one.
+
+Even though this documentation is for vim-slime-ext-neovim, it also reviews the functionality of `vim-slime-ext-plugins` and `vim-slime`
 
 ## Introduction
 
-Imagine that you are making quick changes to, for example, a python script.  One approach to test the changes is to copy and paste into an open python REPL (perhaps using the `+` or `*` registers which can be synced to the system clipboard).  With this plugin you can send the code directly to the REPL using Vim operator /motion+text object combinations. For example, if `SlimeMotionSend` is mapped to `gz`, `gzip` can be used to send an uninterrupted block of text (a paragraph) to the REPL. This of course works for any program running in the terminal that accepts text input.
+Imagine that you are testing quick changes to, for example, a python script.  One approach to test the changes is to copy and paste into an open python REPL in a Neovim terminal (perhaps using the `+` or `*` registers which can be synced to the system clipboard).  With this plugin, instead of copying and pasting, you can send the code directly to the REPL using Vim operator/motion+text object combinations. For example, if `SlimeMotionSend` is mapped to `gz`, `gzip` can be used to send an uninterrupted block of text (a paragraph) to the REPL. This of course works for any program running in the terminal that accepts text input.
 
-## Example Installation Using [lazy.nvim](https://github.com/folke/lazy.nvim)
+## Example Installation and Configuration Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 
-Note that `vim-slime-ext-plugins` is necessary.
+Note that `vim-slime-ext-plugins` is necessary as a dependency.
 
-```
+Be aware that the values here are the ones preferred by the plugin author, not the defaults. The default is for the `vim.g` variables to not exist, which has the same effect as `false`.
+
+```lua
 {
-    'Klafyvel/vim-slime-ext-neovim',
-    dependencies = { "jpalardy/vim-slime-ext-plugins" },
+	'Klafyvel/vim-slime-ext-neovim',
+	dependencies = { "jpalardy/vim-slime-ext-plugins" },
+	init = function()
+		vim.g.slime_no_mappings = true -- I prefer to turn off default mappings; see below for more details
+		-- these next two are essential, telling vim-slime-ext-plugins to use the functions from this plugin
+		vim.g.slime_target_send = "slime_neovim#send"
+		vim.g.slime_target_config = "slime_neovim#config"
+		vim.g.slime_input_pid = false -- use Neovim's internal Job ID rather than PID to select a terminal
+		vim.g.override_status = true -- Show the Job ID and PID in the status bar of a terminal
+		vim.g.ruled_status = true  -- If override_status is true, also show the cursor position in the status bar
+	end,
+	config = function()
+
+		vim.keymap.set("n", "gz", "<Plug>SlimeMotionSend", { remap = true, silent = false })
+		vim.keymap.set("n", "gzz", "<Plug>SlimeLineSend", { remap = true, silent = false })
+		vim.keymap.set("x", "gz", "<Plug>SlimeRegionSend", { remap = true, silent = false })
+
+	end,
 }
 ```
 
+### Vimscript Config
+
+```vim
+let g:slime_no_mappings = 1
+let g:slime_target_send = "slime_neovim#send"
+let g:slime_target_config = "slime_neovim#config"
+let g:slime_input_pid = 0
+let g:override_status = 1
+let g:ruled_status = 1
+map gz <Plug>SlimeMotionSend
+map gzz <Plug>SlimeLineSend
+xmap gz <Plug>SlimeRegionSend
+```
+
+
+It is recommended to use `init` instead of `config` for plugin configuration involving global variables.
+
 ## Usage
+
+If `vim.g.slime_no_mappings = false` default mappings will be defined. If the user provides their own mappings, those specific default mappings will be disabled. 
+
+
+The default mappings are:
+
+- <C-c><C-c> send current paragraph to terminal.
+- {Visual}<c-c><c-c>  Send highlighted text to terminal.
+- <c-c>v configure the target terminal.
 
 Use the `<Plug>` mappings from `vim-slime-ext-plugins` to send text to a running Neovim terminal. Upon running them, if a terminal has not been configured as the target, the user will be prompted to select one based on either the Job Id number or the PID, or to open one if no terminal is detected.
 
-`<Plug>SlimeRegionSend` sends a visually selected region to the terminal.
-`<Plug>SlimeLineSend` sends a line to the terminal.
-`<Plug>SlimeMotionSend` sends text to terminal based on motion or text-object.
-`<Plug>SlimeParagraphSend` sends a paragraph to the terminal.
-`<Plug>SlimeConfig` configure the target terminal for the current buffer.
+- `<Plug>SlimeConfig` configure the target terminal for the current buffer.
+- `<Plug>SlimeRegionSend` sends a visually selected region to the terminal.
+- `<Plug>SlimeLineSend` sends a line to the terminal.
+- `<Plug>SlimeMotionSend` sends text to terminal based on motion or text-object.
+- `<Plug>SlimeParagraphSend` sends a paragraph to the terminal.
+
+For this plugin (`vim-slime-ext-neovim`) if you try to send text to a terminal when none is opened, you will be prompted to do so. If multiple terminals are opened, you are prompted to select the most recently opened terminal, but can select any terminal.
+
+There are additionally commands available (taken from the base Slime documentation):
+
+- `:SlimeConfig` configures the current buffer to select a terminal.
+- `<range>SlimeSend` send the range of lines to the terminal. For example to send lines three through five to the terminal, `:3,5SlimeSend`.
+
+- `:SlimeSend1 {text}` send text to terminal, with a carriage return appended. For example `:SlimeSend1 pwd`.
+
+- `:SlimeSend0 {text in quotes}` send text to terminal, without a carriage return appended. For example `:SlimeSend0 'pwd'`  or  `:SlimeSend0 "pwd"`.
+
 
 ## Configuration
 
-### Variables defined by `vim-slime-ext-plugins`
+### Global Variables
+
+Have to be created and set by the user.  By default they do not exist.
+
+
+---
+
 
 ```
 vim.g.slime_target_config = "slime_neovim#config"
 ```
 
-(defined in `vim-slime-ext-plugins`) This variable holds the function that configures which terminal text is sent to. Here we set it to the configuration function defined in this plugin. 
+(defined in `vim-slime-ext-plugins`) This variable holds the function that configures which terminal text is sent to. Here we set it to the configuration function defined in this plugin.
+
+
+---
 
 
 ```
@@ -45,69 +114,45 @@ vim.g.slime_target_send = "slime_neovim#send"
 (defined in `vim-slime-ext-plugins`) This variable holds the function that actually sends text to the terminal. We set it to the function defined in this plugin.
 
 
+---
+
+
 ```
 vim.g.slime_no_mappings = true
 ```
 
-Do not define the default mappings from `vim-slime-ext-plugins`.  See documentation of `vim-slime-ext-plugins` for more details.
+Do not define the default mappings from `vim-slime-ext-plugins`. Default mappings are also turned off for `SlimeRegionSend`, `SlimeParagraphSend` and `SlimeConfig` if the user has already made their own mappings.  See documentation of `vim-slime-ext-plugins` or `vim-slime` for more details.
+
+
+---
 
 
 ```
-vim.g.slime_input_pid = 0
+vim.g.slime_input_pid = false
 ```
 
-Boolean that can decides whether you specify the terminal based on the Neovim internal terminal Job ID, or based on the PID that also exists on a system level. Job ID is shorter an for that readsn might be preferred.
+Boolean that can decides whether you specify the terminal based on the Neovim internal terminal Job ID, or based on the PID that also exists on a system level. Job ID is shorter an for that reads might be preferred.
+
+
+---
+
+```
+vim.g.override_status = true
+```
+
+Boolean that overrides the default status bar so that Job ID and terminal PID is displayed in the status bar. The default is `false` but it is recommended to set it to true (`1`).
+
+
+---
 
 
 ```
-vim.g.override_status=1
+vim.g.ruled_status = true
 ```
 
-Boolean that overraides the default status bar so that Job ID and terminal PID is displayed in the status bar. Recommended to be true (`1`)
+Boolean that, when true, shows the coordinates of the cursor in the overridden status bar set by `vim.g.override_status`. Only takes effect if `vim.g.override_status` is `true`.
 
 
-
-
-vim.keymap.set("n", "gz", "<Plug>SlimeMotionSend", { remap = true })
-vim.keymap.set("n", "gzz", "<Plug>SlimeLineSend", { remap = true })
-vim.keymap.set("x", "gz", "<Plug>SlimeRegionSend", { remap = true })
-```
-
-
-### Note on `g:slime_input_pid`
-
-Using the external PID instead of Neovim\'s internal job id is
-recommended for ease of use. This setting isn\'t default because Neovim
-internally uses its job id. However, setting this to a nonzero value
-allows users to utilize the PID displayed on the terminal\'s status
-line.
-
-## Usage
-
-Check out `:h slime.txt` for default keybindings. Here\'s a brief
-summary:
-
--   `gz[operator/motion]`: Send text using an operator or motion.
--   In visual mode, `gz` sends the selected text.
--   `gzz` sends the current line.
-
-When sending text, the plugin prioritizes the most recently opened
-terminal. If no terminals are open, you\'ll be prompted to open one. Use
-`<C-w>s` or `<C-w>v` and then `:terminal` to do so. To reconfigure a
-buffer\'s terminal connection, call `:SlimeConfig`.
-
-## Capabilities
-
-### Multiple Terminal Tracking
-
-The plugin tracks multiple terminals using `g:slime_last_channel`. If a
-linked terminal closes, the plugin will prompt you to choose another. If
-issues arise, helpful messages guide the process. Feedback is welcome!
-
-Neovim sends text to a terminal using the `terminal_job_id`, but it also
-tracks the system\'s `terminal_job_pid`. The latter is displayed on each
-terminal\'s status line, making it more user-friendly for manual
-configuration.
 
 ## Glossary
 

--- a/autoload/slime_neovim.vim
+++ b/autoload/slime_neovim.vim
@@ -118,7 +118,8 @@ function! slime_neovim#send(config, text)
 			echo "Terminal not detected: Open a neovim terminal and try again. "
 			return
 		catch /Channel id not valid./
-			echo "Channel id not valid: Open a neovim terminal and try again. "
+			redraw!
+			echon "\n\nChannel id not valid. Try again."
 			return
 		finally
 		endtry

--- a/autoload/slime_neovim.vim
+++ b/autoload/slime_neovim.vim
@@ -2,7 +2,7 @@
 
 " Sets up the configuration for slime_neovim.
 function! slime_neovim#config(config, ...)
-	" Check if function is called internally or by external plugins
+	" Check if function is called internally or by external plugins, likely vim-slime-ext-plugins
 	let internal = a:0 > 0 && a:1 == "internal"
 
 	let config_in = a:config

--- a/autoload/slime_neovim.vim
+++ b/autoload/slime_neovim.vim
@@ -32,13 +32,17 @@ function! slime_neovim#config(config, ...)
 		if exists("g:slime_get_jobid")
 			let id_in = g:slime_get_jobid()
 		else
+			if internal
+			let id_in = input("[internal] jobid: ", str2nr(config_in["neovim"]["jobid"]))
+		else
 			let id_in = input("jobid: ", str2nr(config_in["neovim"]["jobid"]))
+		endif
 			let id_in = str2nr(id_in)
 		endif
 	endif
 
 	" Ensure the id is valid
-	if id_in == -1
+	if id_in == -1  "the id wasn't found translate_pid_to_id
 		if internal
 			throw "No matching job id for the provided pid."
 		else
@@ -119,7 +123,7 @@ function! slime_neovim#send(config, text)
 			return
 		catch /Channel id not valid./
 			redraw!
-			echon "\n\nChannel id not valid. Try again."
+			echon "Channel id not valid. Try again."
 			return
 		finally
 		endtry

--- a/autoload/slime_neovim.vim
+++ b/autoload/slime_neovim.vim
@@ -151,7 +151,7 @@ endfunction
 " Sets the status line if the appropriate flags are enabled.
 function! slime_neovim#SetStatusline()
 	if exists("g:override_status") && g:override_status
-		if exists("g:ruled_terminal") && g:ruled_terminal
+		if exists("g:ruled_status") && g:ruled_status
 			setlocal statusline=%{bufname()}%=%-14.(%l,%c%V%)\ %P\ \|\ id:\ %{b:terminal_job_id}\ pid:\ %{b:terminal_job_pid}
 		else
 			setlocal statusline=%{bufname()}%=id:\ %{b:terminal_job_id}\ pid:\ %{b:terminal_job_pid}

--- a/doc/vim-slime-ext-neovim.txt
+++ b/doc/vim-slime-ext-neovim.txt
@@ -1,220 +1,196 @@
-*vim-slime-ext-neovim.txt*                  Helps send text to neovim terminal
+*vim-slime-ext-neovim.txt* A plugin to extend vim-slime for Neovim
+
+Author: Unknown
+Version: Unknown
+Table of Contents
+- Introduction         |vim-slime-ext-neovim-introduction|
+- Installation         |vim-slime-ext-neovim-installation|
+- Usage                |vim-slime-ext-neovim-usage|
+- Configuration        |vim-slime-ext-neovim-configuration|
+- Global Variables     |vim-slime-ext-neovim-global-variables|
+- Mappings             |vim-slime-ext-neovim-mappings|
+- Glossary             |vim-slime-ext-neovim-glossary|
 
 ==============================================================================
-Table of Contents                     *vim-slime-ext-neovim-table-of-contents*
+INTRODUCTION                                                *vim-slime-ext-neovim-introduction*
 
-1. vim-slime-ext-neovim            |vim-slime-ext-neovim-vim-slime-ext-neovim|
-  - What This Is      |vim-slime-ext-neovim-vim-slime-ext-neovim-what-this-is|
-  - Example of Installation and Configuration Using lazy.nvim|vim-slime-ext-neovim-vim-slime-ext-neovim-example-of-installation-and-configuration-using-lazy.nvim|
-  - Vimscript, Configuration Only|vim-slime-ext-neovim-vim-slime-ext-neovim-vimscript,-configuration-only|
-  - How to Use          |vim-slime-ext-neovim-vim-slime-ext-neovim-how-to-use|
-  - Capabilities Summary|vim-slime-ext-neovim-vim-slime-ext-neovim-capabilities-summary|
-  - Glossary              |vim-slime-ext-neovim-vim-slime-ext-neovim-glossary|
+This is a plugin to send code from a Neovim buffer to a running Neovim 
+terminal. This plugin extends |vim-slime-ext-plugins|, which is itself a 
+modification of |vim-slime|. This documentation is specifically for 
+vim-slime-ext-neovim but also reviews the functionality of vim-slime-ext-plugins 
+and vim-slime.
+
+Imagine you are testing quick changes to a Python script. One way to test 
+changes is to copy and paste into an open Python REPL in a Neovim terminal. 
+With this plugin, you can send the code directly to the REPL using Vim 
+operator/motion+text object combinations.
+
+For example, if |SlimeMotionSend| is mapped to 'gz', 'gzip' can send an 
+uninterrupted block of text (a paragraph) to the REPL. This works for any 
+program in the terminal accepting text input.
 
 ==============================================================================
-1. vim-slime-ext-neovim            *vim-slime-ext-neovim-vim-slime-ext-neovim*
+INSTALLATION                                                *vim-slime-ext-neovim-installation*
 
-A plugin to send code from a neovim Neovim buffer to a running Neovim terminal,
-enhancing your development workflow. This plugin uses Neovim’s built-in
-terminal and extends vim-slime-ext-plugins
-<https://github.com/jpalardy/vim-slime-ext-plugins/>; which must be installed
-for this plugin to work. For help with that plugin once it is installed see
-`h:slime.txt`.
+Note: vim-slime-ext-plugins is a required dependency.
 
+Example installation and configuration using |lazy.nvim|:
 
-WHAT THIS IS          *vim-slime-ext-neovim-vim-slime-ext-neovim-what-this-is*
-
-Say you are writing code in, for example, python. One way of quickly testing
-code is to have a terminal where you repeatedly source commands from the
-terminal. For example if your file is `hello.py` you might have an editor open
-in one window, and a shell open in another where you input `python hello.py`
-after you save changes. Another way might be to copy and paste your code to an
-open python session in the terminal.
-
-The vim-slime <https://github.com/jpalardy/vim-slime> plugin allows the user to
-set keybindings to send text directly from a Vim or Neovim buffer to a running
-shell or window. Configuration code for each target is included in that
-repository.
-
-vim-slime-ext-plugins <https://github.com/jpalardy/vim-slime-ext-plugins/> in
-contrast provides infrastructure for sending text to a target, and leaves the
-community to develop plugins for each target.
-
-This plugin extends `vim-slime-ext-plugins` and targets the built-in Neovim
-terminal, allowing you to send text directly from your buffer. When you try to
-send text, you are prompted with an terminal identification number, which you
-can edit to select a different terminal if multiple are open, you can edit the
-prompt to pick a different one. See details in the usage section below.
-
-
-EXAMPLE OF INSTALLATION AND CONFIGURATION USING LAZY.NVIM*vim-slime-ext-neovim-vim-slime-ext-neovim-example-of-installation-and-configuration-using-lazy.nvim*
-
->lua
-    {
     'Klafyvel/vim-slime-ext-neovim',
     dependencies = { "jpalardy/vim-slime-ext-plugins" },
-    
-    
+    init = function()
+      vim.g.slime_no_mappings = true
+      vim.g.slime_target_send = "slime_neovim#send"
+      vim.g.slime_target_config = "slime_neovim#config"
+      vim.g.slime_input_pid = false
+      vim.g.override_status = true
+      vim.g.ruled_status = true
+    end,
     config = function()
-    
-        --  setting the functions used to send text to the ones defined in this plugin; required by vim-slime-ext-plugins
-        vim.g.slime_target_send = "slime_neovim#send"
-        vim.g.slime_target_config = "slime_neovim#config"
-        -- recommended to show status bars to be able to see terminal job id and pid (is the Neovim default)
-        vim.opt.laststatus = 2
-    
-        -- allows use of PID rather than internal job_id for config see note below this codeblock
-        vim.g.slime_input_pid = 0
-    
-        -- override status bar of terminal to show pid and job id
-        vim.g.override_status = 1
-    
-        -- show position info as the `ruler` setting does
-        vim.g.ruled_terminal = 0
-    
-        -- optional but useful keymaps:
-        ---- send text using gz as operator before motion or text object
-        vim.keymap.set("n", "gz", "<Plug>SlimeMotionSend", { remap = true })
-        ---- send line of text
-        vim.keymap.set("n", "gzz", "<Plug>SlimeLineSend", { remap = true })
-        ---- send visual selection
-        vim.keymap.set("x", "gz", "<Plug>SlimeRegionSend", { remap = true })
+      " Mapping examples here
     end
-    }
-    
-<
 
+It's recommended to use `init` for setting global variables before the plugin 
+loads; otherwise, they might not take effect.
 
-NOTE ON G:SLIME_INPUT_PID ~
+Vimscript configuration is also possible:
 
-Used to send text using the external PID rather than Neovim’s internal job
-id. Set based on preference. **Note that this plugin has the option to override
-the default terminal status line using the g:override_status option** to show
-the pid and job id clearly, on the far right, whereas the default setting only
-includes the pid in the name of the buffer. This will facilitate use of either
-the job id or job pid.
-
-
-ADDITIONAL NOTE
-
-Recall that when configuring neovim in lua, variables in the global `g:`
-namespace are set with `vim.g.foo = bar`.
-
-
-VIMSCRIPT, CONFIGURATION ONLY*vim-slime-ext-neovim-vim-slime-ext-neovim-vimscript,-configuration-only*
-
->vim
-    "   setting the functions used to send text to the ones defined in this plugin; required by vim-slime-ext-plugins
+    let g:slime_no_mappings = 1
     let g:slime_target_send = "slime_neovim#send"
     let g:slime_target_config = "slime_neovim#config"
-    
-    " recommended to show status bars to be able to see terminal job id and pid (is the Neovim default)
-    set laststatus=2
-    " Use external PID instead of Neovim's internal job id
-    let g:slime_input_pid=0
-    
-    " override status bar of terminal to show pid and job id
-    let g:override_status=1
-    
-    " show ruler informaton
-    let g:ruled_terminal=0
-    
-    " Key mappings:
-    " Send text using gz as operator before motion or text object
-    nmap gz <Plug>SlimeMotionSend
-    " Send line of text
-    nmap gzz <Plug>SlimeLineSend
-    " Send visual selection
+    let g:slime_input_pid = 0
+    let g:override_status = 1
+    let g:ruled_status = 1
+    map gz <Plug>SlimeMotionSend
+    map gzz <Plug>SlimeLineSend
     xmap gz <Plug>SlimeRegionSend
-<
+
+Again, it is recommended to use `init` for global variables.
+
+==============================================================================
+USAGE                                                       *vim-slime-ext-neovim-usage*
+
+If `vim.g.slime_no_mappings = false`, default mappings will be defined. 
+Specific default mappings will be disabled if the user provides their own.
+
+Default mappings:
+
+  - <C-c><C-c> : Send the current paragraph to the terminal
+  - {Visual}<C-c><C-c> : Send highlighted text to the terminal
+  - <C-c>v : Configure the target terminal
+
+Additional plug mappings:
+
+  - |<Plug>SlimeConfig| : Configure the terminal for the current buffer
+  - |<Plug>SlimeRegionSend| : Send a visually selected region to the terminal
+  - |<Plug>SlimeLineSend| : Send a line to the terminal
+  - |<Plug>SlimeMotionSend| : Send text to the terminal based on motion/text-object
+
+Additional commands:
+
+  - |:SlimeConfig| : Configure the terminal for the current buffer
+  - |:SlimeSend| : Send a range of lines to the terminal
+  - |:SlimeSend1| : Send text to terminal, with a carriage return
+  - |:SlimeSend0| : Send text to terminal, without a carriage return
+
+If you try to send text when no terminal is opened, you'll be prompted to 
+open one. If multiple terminals are open, you're prompted to select any.
+
+==============================================================================
+CONFIGURATION                                               *vim-slime-ext-neovim-configuration*
+
+Global variables (`vim.g.xxx`) need to be created and set by the user. 
+By default, they do not exist.
+
+Global variables are described in the next section.
 
 
-HOW TO USE              *vim-slime-ext-neovim-vim-slime-ext-neovim-how-to-use*
+==============================================================================
+GLOBAL VARIABLES                                        *vim-slime-ext-neovim-global-variables*
 
-See `:h slime.txt` (from`jpalardy/vim-slime-ext-plugins` which should be
-installed with this plugin) for default keybindings to send text to a target. I
-repeat the suggested additional keymappings from the config section above:
+1. *g:slime_no_mappings*
 
-- `gz[operator/motion]`: send text using an operator or motion.
-- In visual mode `gz` can send visually selected text to the target.
-- `gzz` sends the current line to the target.
+    When set to 1, default mappings are not created. This allows you to 
+    define your own. Default is 0.
 
-Of course these are optional and you can do what you want.
+        let g:slime_no_mappings = 1
 
-When you use one of these motions, the plugin will try to find the most
-recently opened terminal and select it as the target. You are prompted with the
-identification number (`terminal_job_id`) or (`terminal_job_pid` if
-`g:sline_input_pid` is set to a nonzero value). `terminal_job_id` is used by
-default because that is that Neovim internally uses to send text to the
-terminals.
+2. *g:slime_target_send*
 
-This plugin has the option (by setting `g:override_status` to a nonzero value)
-to override the terminal status bar to show both the `terminal_job_id` and
-`terminal_job_pid` on the right, whereas without the override the
-`terminal_job_pid` is just included in the buffer name on the left. Recall that
-`laststatus` should be set to `2` to see a status bar in each window.
+    Specifies the function used for sending text to the terminal.
 
-If no terminals are open when you try to send text to one you will be prompted
-to do so. To do so, open a new split with `<C-w>s` or `<C-w>v` and then enter
-the command `:terminal` (built into neovim, just a reminder of how to do it).
+        let g:slime_target_send = "slime_neovim#send"
 
-Call the `:SlimeConfig` function (defined in the base `vim-slime-ext-plugins`
-plugin) from an open buffer to reconfigure the terminal connection of that
-buffer.
+3. *g:slime_target_config*
 
+    Specifies the function used for configuring the target terminal.
 
-CAPABILITIES SUMMARY*vim-slime-ext-neovim-vim-slime-ext-neovim-capabilities-summary*
+        let g:slime_target_config = "slime_neovim#config"
 
-At the risk of repetition, this plugin:
+4. *g:slime_input_pid*
 
+    When set to 0, disables the prompt for inputting a PID. Default is 1.
 
-KEEPS TRACK OF MULTIPLE TERMINALS ~
+        let g:slime_input_pid = 0
 
-It does this using the `g:slime_last_channel` variable which is an array of
-vimscript dictionaries containing the PIDs (external identifier) and job ids
-(Neovim internal identifier) of open Neovim terminals. If a connected terminal
-is closed, upon trying to send text again the user is prompted to pick another
-terminal, with the next-most recently opened terminal selected by default. If
-no terminals are available, or if there is misconfiguration, a helpful message
-telling you to open a new terminal is displayed. If you find the messages
-aren’t helpful enogh please leave feedback witha repo maintainer.
+5. *g:override_status*
 
+    When set to 1, overrides the status line to indicate the target 
+    terminal. Default is 0.
 
-CAN USE PID OR INTERNAL JOB ID FOR CONFIGURATION ~
+        let g:override_status = 1
 
-Under the hood Neovim sends text to a running a terminal using the
-`terminal_job_id`, which are typically low numbers. Neovim also keeps track of
-the `terminal_job_pid` which is the system’s identifier, and importantly _is
-displayed on the status line of the terinal buffer_. The default settings are
-that the user if prompted with a `terminal_job_id` value, because this is what
-is used by neovim internally to send text to a terminal. However, because it is
-readily displayed for each running terminal, `terminal_job_pid` is much easier
-to manually configure, and that is why `vim.g.slime_input_pid=1` is included in
-the example configuration (the vimscript equivalent of this is `let
-g:slime_input_pid=1`.
+6. *g:ruled_status*
 
+    When set to 1, displays rules in the status line to indicate the target
+    terminal. Default is 0.
 
-CAN OVERRIDE STATUS BAR OF TERMINAL BUFFERS ~
+        let g:ruled_status = 1
 
-To show `terminal_job_id` and `terminal_job_pid` on bottom right, set the
-`g:override_status` variable to a nonzero value. See configuration for
-`g:ruled_terminal` setting, which will turn on or off cursor position
-information. The status line override basically turns off the `ruler` setting
-unless `g:ruled_terminal` is nonzero, in which case the basic `ruler` position
-information is included. Custom `ruler` formats are not supported.
+==============================================================================
+MAPPINGS                                                   *vim-slime-ext-neovim-mappings*
 
+1. *<Plug>SlimeConfig*
 
-GLOSSARY                  *vim-slime-ext-neovim-vim-slime-ext-neovim-glossary*
+    Map this to a key sequence to configure the target terminal for the 
+    current buffer.
 
-- `PID`: In Linux, PID stands for "Process IDentifier". A PID is a unique number
-    that is automatically assigned to each process when it is created on a
-    Unix-like operating system. A process is an executing (i.e., running) instance
-    of a program. Applies to Macos as well. Represented as `terminal_job_pid` in
-    under the `variables` field of the `getbufinfo()` Neovim vimscript command.
-- `job id`: the internal identifier that Neovim attaches to a running terminal
-    process. `termnal_job_id` is the corresponding field in the `variables` section
-    of `getbufinfo()`.
+        nmap <Leader>sc <Plug>SlimeConfig
 
-Generated by panvimdoc <https://github.com/kdheepak/panvimdoc>
+2. *<Plug>SlimeRegionSend*
 
-vim:tw=78:ts=8:noet:ft=help:norl:
+    Map this to a key sequence to send a visually selected region to the 
+    terminal.
+
+        xmap <Leader>s <Plug>SlimeRegionSend
+
+3. *<Plug>SlimeLineSend*
+
+    Map this to a key sequence to send a line to the terminal.
+
+        nmap <Leader>l <Plug>SlimeLineSend
+
+4. *<Plug>SlimeMotionSend*
+
+    Map this to a key sequence to send text to the terminal based on 
+    motion/text-object.
+
+        nmap <Leader>m <Plug>SlimeMotionSend
+
+==============================================================================
+GLOSSARY                                                    *vim-slime-ext-neovim-glossary*
+
+1. REPL - Read Eval Print Loop
+    An interactive environment that takes user input, evaluates it, and 
+    returns the output.
+
+2. PID - Process ID
+    The identifier number that is used by the operating system to manage 
+    running processes.
+
+3. Text Object
+    A contiguous region of text, defined by Vim's motion commands.
+
+4. Motion
+    A Vim command that moves the cursor.
+

--- a/doc/vim-slime-ext-neovim.txt
+++ b/doc/vim-slime-ext-neovim.txt
@@ -1,7 +1,15 @@
-*vim-slime-ext-neovim.txt* A plugin to extend vim-slime for Neovim
+*vim-slime-ext-neovim.txt* 
 
-Author: Unknown
-Version: Unknown
+==============================================================================
+
+A plugin to send code from a Neovim buffer to a running Neovim terminal by extending [vim-slime-ext-plugins](https://github.com/jpalardy/vim-slime-ext-plugins/).
+
+That plugin is itself a modification of [vim-slime](https://github.com/jpalardy/vim-slime) to move platform-specific functionality to extension plugins like this one.
+
+Even though this documentation is for vim-slime-ext-neovim, it also reviews the functionality of `vim-slime-ext-plugins` and `vim-slime`
+
+==============================================================================
+
 Table of Contents
 - Introduction         |vim-slime-ext-neovim-introduction|
 - Installation         |vim-slime-ext-neovim-installation|
@@ -36,25 +44,33 @@ Note: vim-slime-ext-plugins is a required dependency.
 
 Example installation and configuration using |lazy.nvim|:
 
-    'Klafyvel/vim-slime-ext-neovim',
-    dependencies = { "jpalardy/vim-slime-ext-plugins" },
-    init = function()
-      vim.g.slime_no_mappings = true
-      vim.g.slime_target_send = "slime_neovim#send"
-      vim.g.slime_target_config = "slime_neovim#config"
-      vim.g.slime_input_pid = false
-      vim.g.override_status = true
-      vim.g.ruled_status = true
-    end,
-    config = function()
-      " Mapping examples here
-    end
+>lua
+{
+'Klafyvel/vim-slime-ext-neovim',
+dependencies = { "jpalardy/vim-slime-ext-plugins" },
+init = function()
+	vim.g.slime_no_mappings = true -- I prefer to turn off default mappings; see below for more details
+	-- these next two are essential, telling vim-slime-ext-plugins to use the functions from this plugin
+	vim.g.slime_target_send = "slime_neovim#send"
+	vim.g.slime_target_config = "slime_neovim#config"
+	vim.g.slime_input_pid = false -- use Neovim's internal Job ID rather than PID to select a terminal
+	vim.g.override_status = true -- Show the Job ID and PID in the status bar of a terminal
+	vim.g.ruled_status = true  -- If override_status is true, also show the cursor position in the status bar
+
+	--mappings
+	vim.keymap.set("n", "gz", "<Plug>SlimeMotionSend", { remap = true, silent = false })
+	vim.keymap.set("n", "gzz", "<Plug>SlimeLineSend", { remap = true, silent = false })
+	vim.keymap.set("x", "gz", "<Plug>SlimeRegionSend", { remap = true, silent = false })
+end,
+}
+<
 
 It's recommended to use `init` for setting global variables before the plugin 
 loads; otherwise, they might not take effect.
 
 Vimscript configuration is also possible:
 
+>vim
     let g:slime_no_mappings = 1
     let g:slime_target_send = "slime_neovim#send"
     let g:slime_target_config = "slime_neovim#config"
@@ -64,8 +80,8 @@ Vimscript configuration is also possible:
     map gz <Plug>SlimeMotionSend
     map gzz <Plug>SlimeLineSend
     xmap gz <Plug>SlimeRegionSend
+<
 
-Again, it is recommended to use `init` for global variables.
 
 ==============================================================================
 USAGE                                                       *vim-slime-ext-neovim-usage*
@@ -85,22 +101,23 @@ Additional plug mappings:
   - |<Plug>SlimeRegionSend| : Send a visually selected region to the terminal
   - |<Plug>SlimeLineSend| : Send a line to the terminal
   - |<Plug>SlimeMotionSend| : Send text to the terminal based on motion/text-object
+  - |<Plug>SlimeParagraphSend| : Send text to the terminal based on motion/text-object
 
 Additional commands:
 
   - |:SlimeConfig| : Configure the terminal for the current buffer
-  - |:SlimeSend| : Send a range of lines to the terminal
-  - |:SlimeSend1| : Send text to terminal, with a carriage return
-  - |:SlimeSend0| : Send text to terminal, without a carriage return
+  - |:SlimeSend| : Send a range of lines to the terminal. For example to send lines three through five to the terminal, `:3,5SlimeSend`.
+  - |:SlimeSend1| : Send text to terminal, with a carriage return.  For example `:SlimeSend1 pwd`.
+  - |:SlimeSend0| : Send text, wrapped in literal quotes, [;to terminal, without a carriage return.  For example `:SlimeSend0 'pwd'`  or  `:SlimeSend0 "pwd"`.
 
 If you try to send text when no terminal is opened, you'll be prompted to 
-open one. If multiple terminals are open, you're prompted to select any.
+open one. If multiple terminals are open, you're prompted with the most recently opened terminal, but can seledt any.
 
 ==============================================================================
 CONFIGURATION                                               *vim-slime-ext-neovim-configuration*
 
 Global variables (`vim.g.xxx`) need to be created and set by the user. 
-By default, they do not exist.
+By default, they do not exist, which has the same effect as their being `false`.
 
 Global variables are described in the next section.
 
@@ -117,80 +134,42 @@ GLOBAL VARIABLES                                        *vim-slime-ext-neovim-gl
 
 2. *g:slime_target_send*
 
-    Specifies the function used for sending text to the terminal.
+    Specifies the function used for sending text to the terminal. Set to `slim_neovim#send` to use this plugin.
 
         let g:slime_target_send = "slime_neovim#send"
 
 3. *g:slime_target_config*
 
-    Specifies the function used for configuring the target terminal.
+    Specifies the function used for configuring the target terminal.  Set to `slim_neovim#config` to use this plugin.
 
         let g:slime_target_config = "slime_neovim#config"
 
 4. *g:slime_input_pid*
 
-    When set to 0, disables the prompt for inputting a PID. Default is 1.
+    When set to 0, use |job-id| instead of system PID to selecct a terminal.
 
         let g:slime_input_pid = 0
 
+    Note that PID is the identifier number that is used by the operating 
+    system to manage running processes.
+
 5. *g:override_status*
 
-    When set to 1, overrides the status line to indicate the target 
-    terminal. Default is 0.
+    When set to 1, overrides the status line of terminals to show the |job-id| and system PID.
+    terminal.
 
         let g:override_status = 1
 
 6. *g:ruled_status*
 
     When set to 1, displays rules in the status line to indicate the target
-    terminal. Default is 0.
+    terminal.
 
         let g:ruled_status = 1
 
 ==============================================================================
 MAPPINGS                                                   *vim-slime-ext-neovim-mappings*
 
-1. *<Plug>SlimeConfig*
+See  |vim-slime-ext-neovim-usage| and |vim-slime-ext-neovim-installation| for available commands, functions and mapping examples.
 
-    Map this to a key sequence to configure the target terminal for the 
-    current buffer.
-
-        nmap <Leader>sc <Plug>SlimeConfig
-
-2. *<Plug>SlimeRegionSend*
-
-    Map this to a key sequence to send a visually selected region to the 
-    terminal.
-
-        xmap <Leader>s <Plug>SlimeRegionSend
-
-3. *<Plug>SlimeLineSend*
-
-    Map this to a key sequence to send a line to the terminal.
-
-        nmap <Leader>l <Plug>SlimeLineSend
-
-4. *<Plug>SlimeMotionSend*
-
-    Map this to a key sequence to send text to the terminal based on 
-    motion/text-object.
-
-        nmap <Leader>m <Plug>SlimeMotionSend
-
-==============================================================================
-GLOSSARY                                                    *vim-slime-ext-neovim-glossary*
-
-1. REPL - Read Eval Print Loop
-    An interactive environment that takes user input, evaluates it, and 
-    returns the output.
-
-2. PID - Process ID
-    The identifier number that is used by the operating system to manage 
-    running processes.
-
-3. Text Object
-    A contiguous region of text, defined by Vim's motion commands.
-
-4. Motion
-    A Vim command that moves the cursor.
 

--- a/plugin/slime-neovim.vim
+++ b/plugin/slime-neovim.vim
@@ -1,17 +1,11 @@
 " autocmds to keep of terminal identification numbers whenever a terminal is opened or closed
-function! s:SetStatusline()
-	if exists("g:override_status") && g:override_status
-		if exists("g:ruled_terminal") && g:ruled_terminal
-			setlocal statusline=%{bufname()}%=%-14.(%l,%c%V%)\ %P\ \|\ id:\ %{b:terminal_job_id}\ pid:\ %{b:terminal_job_pid}
-		else
-			setlocal statusline=%{bufname()}%=id:\ %{b:terminal_job_id}\ pid:\ %{b:terminal_job_pid}
-		endif
-	endif
-endfunction
 
 augroup nvim_slime
 	autocmd!
+	" keeping track of channels that are open
 	autocmd TermOpen * call slime_neovim#SlimeAddChannel()
+	" keeping track when terminals are closed
 	autocmd TermClose * let b:terminal_closed = 1 | call slime_neovim#SlimeClearChannel()
-	autocmd TermOpen * call s:SetStatusline()
+	" setting status line to show job id and pid of terminal
+	autocmd TermOpen * call slime_neovim#SetStatusline()
 augroup END

--- a/plugin/slime-neovim.vim
+++ b/plugin/slime-neovim.vim
@@ -12,6 +12,6 @@ endfunction
 augroup nvim_slime
 	autocmd!
 	autocmd TermOpen * call slime_neovim#SlimeAddChannel()
-	autocmd TermClose * call slime_neovim#SlimeClearChannel()
+	autocmd TermClose * let b:terminal_closed = 1 | call slime_neovim#SlimeClearChannel()
 	autocmd TermOpen * call s:SetStatusline()
 augroup END


### PR DESCRIPTION
There was  a bug that I didn't catch because I have an autocommand that closes my terminal in vim 0.9.xxxx when the terminal process finishes running. Because the buffer didn't close, it wasn't reflected in `slime_last_channel`.

This is fixed with the lines 

```
autocmd TermClose * let b:terminal_closed = 1 | call slime_neovim#SlimeClearChannel()
```

and

```
call filter(bufinfo, {_, val -> has_key(val['variables'], "terminal_job_id") && has_key(val['variables'], "terminal_job_pid") && !get(val['variables'],"terminal_closed",0)})
````
.

I also cleaned up the documentation.


I had more features but that was  contingent on [this pull request](https://github.com/jpalardy/vim-slime-ext-plugins/pull/8) being accepted.  

Because jpalardy isn't going to devote any more energy to vim-slime-ext-plugins this is my last pr for this repo for the foreseeable future. I will try to implement those features in the main vim-slime repo.